### PR TITLE
Bug fix, or kind of "excelsior"?

### DIFF
--- a/src/main/java/com/github/gamepiaynmo/custommodel/mixin/PlayerStatureHandler.java
+++ b/src/main/java/com/github/gamepiaynmo/custommodel/mixin/PlayerStatureHandler.java
@@ -49,8 +49,15 @@ public class PlayerStatureHandler {
             AbstractClientPlayer clientPlayer = (AbstractClientPlayer) player;
             ModelPack pack = CustomModelClient.manager.getModelForPlayer(clientPlayer);
             if (pack != null) {
-                if (CustomModelClient.serverConfig.customEyeHeight && event.phase == TickEvent.Phase.START) {
+                //changed event phase to END, because START feels "delayed by 1 tick"
+                //possibly because entity state is updated at phase "MIDDLE"?
+                //also in vanilla, when you are not standing ON THE GROUND, sneaking will not change eye height,
+                //but sneaking do change the "pose"
+                if (CustomModelClient.serverConfig.customEyeHeight && event.phase == TickEvent.Phase.END) {
                     Float eyeHeight = pack.getModel().getModelInfo().eyeHeightMap.get(pose);
+                    if (pose == EntityPose.SNEAKING && !player.onGround) {
+                        eyeHeight = pack.getModel().getModelInfo().eyeHeightMap.get(EntityPose.STANDING);
+                    }
                     if (eyeHeight != null)
                         player.eyeHeight = eyeHeight;
                     else player.eyeHeight = player.getDefaultEyeHeight();
@@ -66,8 +73,15 @@ public class PlayerStatureHandler {
             EntityPlayerMP serverPlayer = (EntityPlayerMP) player;
             ModelInfo pack = CustomModel.manager.getModelForPlayer(serverPlayer);
             if (pack != null) {
-                if (ModConfig.isCustomEyeHeight() && event.phase == TickEvent.Phase.START) {
+                //changed event phase to END, because START feels "delayed by 1 tick"
+                //possibly because entity state is updated at phase "MIDDLE"?
+                //also in vanilla, when you are not standing ON THE GROUND, sneaking will not change eye height,
+                //but sneaking do change the "pose"
+                if (ModConfig.isCustomEyeHeight() && event.phase == TickEvent.Phase.END) {
                     Float eyeHeight = pack.eyeHeightMap.get(pose);
+                    if (pose == EntityPose.SNEAKING && !player.onGround) {
+                        eyeHeight = pack.eyeHeightMap.get(EntityPose.STANDING);
+                    }
                     if (eyeHeight != null)
                         player.eyeHeight = eyeHeight;
                     else player.eyeHeight = player.getDefaultEyeHeight();


### PR DESCRIPTION
Fixed the problem of "eye height changes has 1 tick delay" and the problem of sneaking when jumping or creative flying changes the eye height (in vanilla, your eye height changes only when the player is standing on the ground).

Yeah these two problems feels like finding fault with this mod... But no, I just found myself attracted to such a way to customize player model whilst keeping all the vanilla features, so I want this project to be as good as possible, and provide some humble help.

I think the delay is caused by the fact that player status is updated in the "MIDDLE" of a tick, so if the eye height is updated "right before each tick", then when a player sneaks, in the next "tick gap", the status is updated (the model and bounding box are changed), but the eye height is not, so when rendering frames it feels kind of delayed (like the video game has a 50ms lag?)
So I changed the trigger phase to END, which fixes the problem.

I guess changing the phase isn't messing other things up? (At least I haven't observed any)