### PR TITLE
some features (mainly focuses on particles)

### DIFF
--- a/src/main/java/com/github/gamepiaynmo/custommodel/client/render/CustomJsonModel.java
+++ b/src/main/java/com/github/gamepiaynmo/custommodel/client/render/CustomJsonModel.java
@@ -80,6 +80,8 @@ public class CustomJsonModel {
     public static final String SIZE = "size";
     public static final String GRAVITY = "gravity";
     public static final String COLLIDE = "collide";
+    //added brightness control of particles
+    public static final String BRIGHTNESS = "brightness";
     public static final String ITEM_ID = "itemId";
     public static final String ENCHANTED = "enchanted";
 

--- a/src/main/java/com/github/gamepiaynmo/custommodel/client/render/model/CustomParticle.java
+++ b/src/main/java/com/github/gamepiaynmo/custommodel/client/render/model/CustomParticle.java
@@ -21,6 +21,10 @@ public class CustomParticle extends Particle {
     protected ResourceLocation texture;
 
     private float minU, maxU, minV, maxV;
+    //added an option, making the particle glow in the dark, and controls the brightness
+    private boolean emissive;
+    private float brightnessStart;
+    private float brightnessEnd;
 
     protected CustomParticle(World world_1, ParticleEmitter emitter, Vector3 pos, Vector3 dir) {
         super(world_1, pos.x, pos.y, pos.z);
@@ -60,11 +64,43 @@ public class CustomParticle extends Particle {
     public void setSize(float size) { this.particleScale = size; }
     public void setAlpha(float alpha) { this.setAlphaF(alpha); }
     public void setTexture(ResourceLocation texture) { this.texture = texture; }
+    //added an option, making the particle glow in the dark, and controls the brightness
+    public void setEmissive(boolean emissive) {
+        this.emissive = emissive;
+    }
+    public void setBrightnessStart(float brightnessStart) {
+        this.brightnessStart = brightnessStart;
+    }
+    public void setBrightnessEnd(float brightnessEnd) {
+        this.brightnessEnd = brightnessEnd;
+    }
 
     public ResourceLocation getTexture() { return texture; }
     public Vec3d getPos() { return new Vec3d(posX, posY, posZ); }
 
     public boolean isReleased() { return emitter.released; }
+
+    //if the particle is not emissive, then use the normal brightness
+    //otherwise, use the brightness of flame particles, but adjusted to control the brightness
+    @Override
+    public int getBrightnessForRender(float p_getBrightnessForRender_1_) {
+        if (!this.emissive) {
+            return super.getBrightnessForRender(p_getBrightnessForRender_1_);
+        }
+        float lvt_2_1_ = ((float)this.particleAge + p_getBrightnessForRender_1_) / (float)this.particleMaxAge;
+        lvt_2_1_ = MathHelper.clamp(lvt_2_1_, 0.0F, 1.0F);
+        //adjusted to control the brightness
+        lvt_2_1_ = (float) MathHelper.clampedLerp(this.brightnessStart, this.brightnessEnd, lvt_2_1_);
+        int lvt_3_1_ = super.getBrightnessForRender(p_getBrightnessForRender_1_);
+        int lvt_4_1_ = lvt_3_1_ & 255;
+        int lvt_5_1_ = lvt_3_1_ >> 16 & 255;
+        lvt_4_1_ += (int)(lvt_2_1_ * 15.0F * 16.0F);
+        if (lvt_4_1_ > 240) {
+            lvt_4_1_ = 240;
+        }
+
+        return lvt_4_1_ | lvt_5_1_ << 16;
+    }
 
     private void calcUV() {
         int cnt = emitter.animation[0] * emitter.animation[1];

--- a/src/main/java/com/github/gamepiaynmo/custommodel/client/render/model/ParticleEmitter.java
+++ b/src/main/java/com/github/gamepiaynmo/custommodel/client/render/model/ParticleEmitter.java
@@ -32,6 +32,8 @@ public class ParticleEmitter {
     private IExpressionFloat[] sizeExpr;
     private IExpressionFloat gravityExpr;
     private IExpressionBool collideExpr;
+    //controls the progress of shining, for now only supports linear changing
+    private IExpressionFloat[] brightnessExpr;
 
     protected Vector3 posRange = Vector3.Zero.cpy();
     protected float dirRange;
@@ -45,6 +47,8 @@ public class ParticleEmitter {
     protected float[] size = new float[2];
     protected float gravity;
     protected boolean collide;
+    //controls the progress of shining, for now only supports linear changing
+    protected float[] brightness = new float[2];
 
     protected double timer;
     private Random random = new Random();
@@ -77,6 +81,8 @@ public class ParticleEmitter {
         emitter.sizeExpr = Json.parseFloatExpressionArray(jsonObj.get(CustomJsonModel.SIZE), 2, new float[] {1, 1}, parser);
         emitter.gravityExpr = Json.getFloatExpression(jsonObj, CustomJsonModel.GRAVITY, 0, parser);
         emitter.collideExpr = Json.getBooleanExpression(jsonObj, CustomJsonModel.COLLIDE, false, parser);
+        //controls the progress of shining, for now only supports linear changing
+        emitter.brightnessExpr = Json.parseFloatExpressionArray(jsonObj.get(CustomJsonModel.BRIGHTNESS), 2, new float[] {1, 1}, parser);
 
         return emitter;
     }
@@ -111,6 +117,8 @@ public class ParticleEmitter {
                 evalFloatArray(size, sizeExpr, context);
                 gravity = gravityExpr.eval(context);
                 collide = collideExpr.eval(context);
+                //controls the progress of shining, for now only supports linear changing
+                evalFloatArray(brightness, brightnessExpr, context);
 
                 Vector3 epos = new Vector3();
                 epos.x = transform.val[12] + context.currentEntity.posX;
@@ -150,6 +158,10 @@ public class ParticleEmitter {
                     particle.setGravity(gravity);
                     particle.setCollide(collide);
                     particle.setTexture(bone.getTexture(context).apply(context));
+                    //whether the particles shall glow in the dark, and how the brightness changes over time
+                    particle.setEmissive(bone.isEmissive());
+                    particle.setBrightnessStart(brightness[0]);
+                    particle.setBrightnessEnd(brightness[1]);
 
                     manager.addEffect(particle);
                 }

--- a/src/main/java/com/github/gamepiaynmo/custommodel/expression/RenderEntityParameterBool.java
+++ b/src/main/java/com/github/gamepiaynmo/custommodel/expression/RenderEntityParameterBool.java
@@ -2,6 +2,8 @@ package com.github.gamepiaynmo.custommodel.expression;
 
 import com.github.gamepiaynmo.custommodel.client.CustomModelClient;
 import com.github.gamepiaynmo.custommodel.client.render.RenderContext;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 
@@ -21,7 +23,13 @@ public enum RenderEntityParameterBool implements IExpressionBool {
    IS_SPRINTING("is_sprinting", Entity::isSprinting),
    IS_WET("is_wet", Entity::isWet),
    IS_INVENTORY("is_inventory", entity -> CustomModelClient.isRenderingInventory),
-   IS_FIRST_PERSON("is_first_person", entity -> CustomModelClient.isRenderingFirstPerson);
+   IS_FIRST_PERSON("is_first_person", entity -> CustomModelClient.isRenderingFirstPerson),
+   //this expression is added in order to handle the need to render particles only in third person view
+   //for example putting particles on model's fist
+   //seems that this will only be called on client side, so boldly writing "getMinecraft" won't crash the server
+   IS_CAMERA_FIRST_PERSON("is_camera_first_person",
+           entity -> Minecraft.getMinecraft().gameSettings.thirdPersonView == 0
+                   && entity.equals(Minecraft.getMinecraft().player));
 
    private String name;
    private static final RenderEntityParameterBool[] VALUES = values();


### PR DESCRIPTION
When I'm working on the particle system, it seems that "is_first_person" doesn't actually stop particles from rendering, which means that this "is_first_person" refers to the "bone" instead of the "camera", i.e. the bone is part of the third person model or first person model (kind of like "additional" two arms).

The situation is that I bound some particles to the hand of my character and put "!is_first_person" in the bone's visibility condition, but when I am in first person view, the particles show as if the third person model is merely "hidden" (they appear at the position of my "third person hands" and swings back and forth when I walk, and follows the facing of the "third person body").

So I added one more function which checks if the current entity is "the player" and "the client" is in first person view.

I know the "getMinecraft" shall only be performed on the client side, but through my tests it seems that those functions are only called at client side so it seems fine? But this part is still makes me concerned... Maybe some security check are needed to prevent that from accidentally breaking the server.

------------------------

Also, I found that emissive bones wouldn't bring emissive particles, so I added a little brightness system to particles so that they shine properly and can be controlled.

However, for now, I can only make the brightness change linearly (setting the brightness of the start and the end).